### PR TITLE
Update QueryEntitiesResult.php for NextRowKey fix

### DIFF
--- a/azure-storage-table/src/Table/Models/QueryEntitiesResult.php
+++ b/azure-storage-table/src/Table/Models/QueryEntitiesResult.php
@@ -66,7 +66,9 @@ class QueryEntitiesResult
             Resources::X_MS_CONTINUATION_NEXTROWKEY
         );
 
-        if ($nextRK != null && $nextPK != null) {
+        // Note that in some instances, x-ms-continuation-NextRowKey ($nextRK) may be null.
+        // Ref: https://docs.microsoft.com/en-us/rest/api/storageservices/query-timeout-and-pagination
+        if ($nextPK != null) {
             $result->setContinuationToken(
                 new TableContinuationToken(
                     '',


### PR DESCRIPTION
Do not check the $nextRK, because according to the documentation, the x-ms-continuation-NextRowKey may be null.